### PR TITLE
fix: Selectでラベルが値の上に被さってしまう

### DIFF
--- a/src/client/pages/NewPage.svelte
+++ b/src/client/pages/NewPage.svelte
@@ -223,6 +223,7 @@
                     <Header>時間制限</Header>
                     <Content>
                         <Select
+                            key={(v) => v.label}
                             disabled={emitting}
                             bind:value={timer}
                             label="!timer"

--- a/src/client/parts/ResFormPart.svelte
+++ b/src/client/parts/ResFormPart.svelte
@@ -104,7 +104,12 @@
   {/snippet}
 </Textfield>
 
-<Select {disabled} bind:value={contentType} label="本文の形式">
+<Select
+  {disabled}
+  key={(v) => v.label}
+  bind:value={contentType}
+  label="本文の形式"
+>
   {#each contentTypeOptions as v}
     {#if (v.bit & contentTypesBitmask) !== 0}
       <Option value={v.bit}>{v.label}</Option>


### PR DESCRIPTION
smuiのSelectコンポーネントでstring型以外を値に渡すとラベルが値の上に被さります。

https://github.com/hperrin/svelte-material-ui/issues/433#issuecomment-1236564274 で言及されているようにSelectのkey propでこれを回避します。
![bug](https://github.com/user-attachments/assets/21ca02cb-118e-46ca-a5c7-b247868f0655)
