### PR TITLE
add: csp for script-src

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <meta name="description" content="ＮＥＸＴおんＪ">
+  <meta http-equiv="Content-Security-Policy"
+    content="script-src 'self' https://static.cloudflareinsights.com/beacon.min.js 'unsafe-eval'">
   <meta name="author" content="おんＪ民">
   <title>うんｊ</title>
   <link rel="icon" href="%BASE_URL%static/favicons/favicon.ico" />


### PR DESCRIPTION
script-srcに'self'とcloudflareのスクリプト、現状難読化ビルドでevalを使っているため'unsafe-eval'を指定したmetaタグのCSPを追加します。
これによりヘッダーを操作できないGitHub Pagesなどの静的ホスティングでもXSSを防ぎます。

詳細な動作：
万が一、スクリプトタグが送られてきてHTMLとして埋め込んでしてしまってもブロックできます。
ただunsafe-evalが指定されているため、ユーザーからJSのコードが送られてきてevalやFunction()などで評価してしまった場合はブロックされません。